### PR TITLE
Fix file headers for ELPA compatibility

### DIFF
--- a/emagician-fix-spell-memory.el
+++ b/emagician-fix-spell-memory.el
@@ -1,4 +1,4 @@
-;;; emagician-fix-spelling. --- Simple hack into ispell to fix (muscle) memory problems
+;;; emagician-fix-spell-memory.el --- Simple hack into ispell to fix (muscle) memory problems
  
 ;; Copyright (C) 2012 Jonathan Arkell
 


### PR DESCRIPTION
This fix makes the library parseable by `package-buffer-info`, and hence installable via the automatically-built package on [MELPA](http://melpa.milkbox.net).
